### PR TITLE
feat: 实现后台线索管理列表页

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+data/leads.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,1 @@
+{"name":"hello-world","version":"1.0.0","private":true,"description":"Lead capture website and admin MVP","main":"server.js","scripts":{"start":"node server.js","test":"node --test"}}

--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>后台线索管理</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <main class="page admin-page">
+      <section class="admin-panel">
+        <div class="admin-header">
+          <div>
+            <p class="eyebrow">Admin</p>
+            <h1>线索列表</h1>
+            <p class="description">查看已提交的线索，并更新当前跟进状态。</p>
+          </div>
+          <a class="back-link" href="/">返回官网</a>
+        </div>
+
+        <p id="admin-feedback" class="feedback" role="status" aria-live="polite"></p>
+
+        <div class="table-wrap">
+          <table class="lead-table">
+            <thead>
+              <tr>
+                <th>姓名</th>
+                <th>手机号</th>
+                <th>公司</th>
+                <th>留言</th>
+                <th>状态</th>
+                <th>提交时间</th>
+              </tr>
+            </thead>
+            <tbody id="lead-table-body">
+              <tr>
+                <td colspan="6" class="empty-cell">加载中...</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+
+    <script>
+      const feedback = document.getElementById('admin-feedback');
+      const tableBody = document.getElementById('lead-table-body');
+      const statuses = ['new', 'contacted', 'closed'];
+
+      function formatTime(value) {
+        if (!value) return '-';
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) return value;
+        return new Intl.DateTimeFormat('zh-CN', {
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit',
+          hour: '2-digit',
+          minute: '2-digit'
+        }).format(date);
+      }
+
+      function setFeedback(message, type) {
+        feedback.textContent = message || '';
+        feedback.className = 'feedback';
+        if (type) {
+          feedback.classList.add(type === 'error' ? 'feedback-error' : 'feedback-success');
+        }
+      }
+
+      function renderEmpty(message) {
+        tableBody.innerHTML = `<tr><td colspan="6" class="empty-cell">${message}</td></tr>`;
+      }
+
+      function renderRows(leads) {
+        if (!leads.length) {
+          renderEmpty('暂无线索数据');
+          return;
+        }
+
+        tableBody.innerHTML = leads.map((lead) => `
+          <tr>
+            <td>${lead.name || '-'}</td>
+            <td>${lead.phone || '-'}</td>
+            <td>${lead.company || '-'}</td>
+            <td class="message-cell">${lead.message || '-'}</td>
+            <td>
+              <select class="status-select" data-lead-id="${lead.id}" aria-label="更新 ${lead.name || '线索'} 状态">
+                ${statuses.map((status) => `<option value="${status}" ${lead.status === status ? 'selected' : ''}>${status}</option>`).join('')}
+              </select>
+            </td>
+            <td>${formatTime(lead.createdAt)}</td>
+          </tr>
+        `).join('');
+      }
+
+      async function loadLeads() {
+        try {
+          const response = await fetch('/api/admin/leads');
+          const result = await response.json();
+          if (!response.ok) {
+            throw new Error(result.message || '加载线索失败。');
+          }
+          renderRows(Array.isArray(result.data) ? result.data : []);
+        } catch (error) {
+          renderEmpty('线索加载失败，请稍后重试');
+          setFeedback(error.message || '线索加载失败。', 'error');
+        }
+      }
+
+      async function handleStatusChange(event) {
+        const select = event.target.closest('.status-select');
+        if (!select) return;
+
+        const previous = select.dataset.previousValue || select.value;
+        const nextStatus = select.value;
+        const leadId = select.dataset.leadId;
+
+        select.disabled = true;
+        setFeedback('状态更新中...', 'success');
+
+        try {
+          const response = await fetch(`/api/admin/leads/${leadId}/status`, {
+            method: 'PATCH',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ status: nextStatus })
+          });
+          const result = await response.json();
+          if (!response.ok) {
+            throw new Error(result.message || '状态更新失败。');
+          }
+          setFeedback(result.message || '状态更新成功。', 'success');
+          await loadLeads();
+        } catch (error) {
+          select.value = previous;
+          setFeedback(error.message || '状态更新失败。', 'error');
+        } finally {
+          select.disabled = false;
+        }
+      }
+
+      tableBody.addEventListener('focusin', (event) => {
+        const select = event.target.closest('.status-select');
+        if (select) {
+          select.dataset.previousValue = select.value;
+        }
+      });
+
+      tableBody.addEventListener('change', handleStatusChange);
+
+      loadLeads();
+    </script>
+  </body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>官网留资</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <main class="page">
+      <section class="hero">
+        <div>
+          <p class="eyebrow">Lead Capture MVP</p>
+          <h1>留下联系方式，获取产品咨询方案</h1>
+          <p class="description">
+            填写基础信息后，我们会尽快与您联系，提供适合您业务场景的解决建议。
+          </p>
+          <p class="admin-entry"><a href="/admin">进入后台查看线索</a></p>
+        </div>
+        <form id="lead-form" class="lead-form" novalidate>
+          <div class="field-group">
+            <label for="name">姓名 *</label>
+            <input id="name" name="name" type="text" autocomplete="name" />
+            <p class="error" data-error-for="name"></p>
+          </div>
+
+          <div class="field-group">
+            <label for="phone">手机号 *</label>
+            <input id="phone" name="phone" type="tel" autocomplete="tel" />
+            <p class="error" data-error-for="phone"></p>
+          </div>
+
+          <div class="field-group">
+            <label for="company">公司</label>
+            <input id="company" name="company" type="text" autocomplete="organization" />
+          </div>
+
+          <div class="field-group">
+            <label for="message">留言</label>
+            <textarea id="message" name="message" rows="4"></textarea>
+          </div>
+
+          <button id="submit-button" type="submit">提交线索</button>
+          <p id="form-feedback" class="feedback" role="status" aria-live="polite"></p>
+        </form>
+      </section>
+    </main>
+
+    <script>
+      const form = document.getElementById('lead-form');
+      const feedback = document.getElementById('form-feedback');
+      const submitButton = document.getElementById('submit-button');
+
+      function setError(field, message) {
+        const errorNode = document.querySelector(`[data-error-for="${field}"]`);
+        if (errorNode) {
+          errorNode.textContent = message;
+        }
+      }
+
+      function clearErrors() {
+        setError('name', '');
+        setError('phone', '');
+      }
+
+      function validate(values) {
+        clearErrors();
+        let valid = true;
+
+        if (!values.name.trim()) {
+          setError('name', '请输入姓名。');
+          valid = false;
+        }
+
+        if (!values.phone.trim()) {
+          setError('phone', '请输入手机号。');
+          valid = false;
+        }
+
+        return valid;
+      }
+
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+
+        const values = {
+          name: form.name.value,
+          phone: form.phone.value,
+          company: form.company.value,
+          message: form.message.value
+        };
+
+        feedback.textContent = '';
+        feedback.className = 'feedback';
+
+        if (!validate(values)) {
+          feedback.textContent = '请先完善必填信息。';
+          feedback.classList.add('feedback-error');
+          return;
+        }
+
+        submitButton.disabled = true;
+        submitButton.textContent = '提交中...';
+
+        try {
+          const response = await fetch('/api/leads', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(values)
+          });
+
+          const result = await response.json();
+
+          if (!response.ok) {
+            throw new Error(result.message || '提交失败，请稍后重试。');
+          }
+
+          feedback.textContent = result.message || '提交成功，我们会尽快与您联系。';
+          feedback.classList.add('feedback-success');
+          form.reset();
+          clearErrors();
+        } catch (error) {
+          feedback.textContent = error.message || '提交失败，请稍后重试。';
+          feedback.classList.add('feedback-error');
+        } finally {
+          submitButton.disabled = false;
+          submitButton.textContent = '提交线索';
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,210 @@
+:root {
+  color-scheme: light;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  color: #1f2937;
+  background: #f3f4f6;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+.page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 32px 16px;
+}
+
+.hero,
+.admin-panel {
+  width: min(1100px, 100%);
+  padding: 32px;
+  border-radius: 24px;
+  background: #ffffff;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.12);
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 32px;
+}
+
+.admin-page {
+  align-items: start;
+}
+
+.eyebrow {
+  margin: 0 0 12px;
+  color: #2563eb;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 12px;
+}
+
+h1 {
+  margin: 0 0 16px;
+  font-size: clamp(32px, 4vw, 48px);
+  line-height: 1.1;
+}
+
+.description {
+  margin: 0;
+  color: #4b5563;
+}
+
+.admin-entry,
+.back-link {
+  margin-top: 20px;
+}
+
+.admin-entry a,
+.back-link {
+  color: #2563eb;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.lead-form {
+  display: grid;
+  gap: 16px;
+}
+
+.field-group {
+  display: grid;
+  gap: 8px;
+}
+
+label {
+  font-weight: 600;
+}
+
+input,
+textarea,
+button,
+select {
+  font: inherit;
+}
+
+input,
+textarea,
+select {
+  width: 100%;
+  padding: 12px 14px;
+  border: 1px solid #d1d5db;
+  border-radius: 12px;
+  background: #fff;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  outline: 2px solid #93c5fd;
+  border-color: #2563eb;
+}
+
+button {
+  border: none;
+  border-radius: 12px;
+  padding: 14px 18px;
+  color: #fff;
+  background: #2563eb;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+button:disabled,
+select:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
+.error {
+  min-height: 20px;
+  margin: 0;
+  color: #dc2626;
+  font-size: 14px;
+}
+
+.feedback {
+  min-height: 24px;
+  margin: 0 0 16px;
+  font-weight: 600;
+}
+
+.feedback-success {
+  color: #15803d;
+}
+
+.feedback-error {
+  color: #dc2626;
+}
+
+.admin-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+  margin-bottom: 16px;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+.lead-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+}
+
+.lead-table th,
+.lead-table td {
+  padding: 14px 12px;
+  border-bottom: 1px solid #e5e7eb;
+  vertical-align: top;
+  text-align: left;
+}
+
+.lead-table th {
+  font-size: 14px;
+  color: #374151;
+  background: #f9fafb;
+}
+
+.message-cell {
+  min-width: 220px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.empty-cell {
+  text-align: center;
+  color: #6b7280;
+}
+
+.status-select {
+  min-width: 140px;
+}
+
+@media (max-width: 800px) {
+  .hero {
+    grid-template-columns: 1fr;
+    padding: 24px;
+  }
+
+  .admin-panel {
+    padding: 24px;
+  }
+
+  .admin-header {
+    flex-direction: column;
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,208 @@
+const http = require('node:http');
+const fs = require('node:fs');
+const path = require('node:path');
+const { randomUUID } = require('node:crypto');
+const { URL } = require('node:url');
+
+const PORT = Number(process.env.PORT || 3000);
+const publicDir = path.join(__dirname, 'public');
+const dataDir = path.join(__dirname, 'data');
+const leadsFile = path.join(dataDir, 'leads.json');
+const VALID_STATUSES = ['new', 'contacted', 'closed'];
+
+function ensureLeadsFile() {
+  if (!fs.existsSync(dataDir)) {
+    fs.mkdirSync(dataDir, { recursive: true });
+  }
+
+  if (!fs.existsSync(leadsFile)) {
+    fs.writeFileSync(leadsFile, '[]\n', 'utf8');
+  }
+}
+
+function readLeads() {
+  ensureLeadsFile();
+  const raw = fs.readFileSync(leadsFile, 'utf8');
+  const parsed = JSON.parse(raw || '[]');
+  return Array.isArray(parsed) ? parsed : [];
+}
+
+function writeLeads(leads) {
+  ensureLeadsFile();
+  fs.writeFileSync(leadsFile, `${JSON.stringify(leads, null, 2)}\n`, 'utf8');
+}
+
+function sendJson(res, statusCode, payload) {
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json; charset=utf-8'
+  });
+  res.end(JSON.stringify(payload));
+}
+
+function serveStaticFile(res, filePath, contentType) {
+  fs.readFile(filePath, (error, content) => {
+    if (error) {
+      sendJson(res, 500, { message: '服务器暂时不可用，请稍后重试。' });
+      return;
+    }
+
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(content);
+  });
+}
+
+async function collectBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+
+    req.on('data', (chunk) => {
+      body += chunk;
+      if (body.length > 1e6) {
+        reject(new Error('Payload too large'));
+        req.destroy();
+      }
+    });
+
+    req.on('end', () => resolve(body));
+    req.on('error', reject);
+  });
+}
+
+function validateLead(input) {
+  const name = String(input.name || '').trim();
+  const phone = String(input.phone || '').trim();
+  const company = String(input.company || '').trim();
+  const message = String(input.message || '').trim();
+
+  if (!name) {
+    return { ok: false, message: '请输入姓名。' };
+  }
+
+  if (!phone) {
+    return { ok: false, message: '请输入手机号。' };
+  }
+
+  return {
+    ok: true,
+    value: { name, phone, company, message }
+  };
+}
+
+function updateLeadStatus(id, status) {
+  if (!VALID_STATUSES.includes(status)) {
+    return { ok: false, statusCode: 400, message: '状态无效。' };
+  }
+
+  const leads = readLeads();
+  const lead = leads.find((item) => item.id === id);
+
+  if (!lead) {
+    return { ok: false, statusCode: 404, message: '线索不存在。' };
+  }
+
+  lead.status = status;
+  lead.updatedAt = new Date().toISOString();
+  writeLeads(leads);
+
+  return { ok: true, value: lead };
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, 'http://127.0.0.1');
+
+  if (req.method === 'GET' && url.pathname === '/') {
+    return serveStaticFile(res, path.join(publicDir, 'index.html'), 'text/html; charset=utf-8');
+  }
+
+  if (req.method === 'GET' && url.pathname === '/admin') {
+    return serveStaticFile(res, path.join(publicDir, 'admin.html'), 'text/html; charset=utf-8');
+  }
+
+  if (req.method === 'GET' && url.pathname === '/styles.css') {
+    return serveStaticFile(res, path.join(publicDir, 'styles.css'), 'text/css; charset=utf-8');
+  }
+
+  if (req.method === 'POST' && url.pathname === '/api/leads') {
+    try {
+      const rawBody = await collectBody(req);
+      const parsedBody = rawBody ? JSON.parse(rawBody) : {};
+      const validation = validateLead(parsedBody);
+
+      if (!validation.ok) {
+        return sendJson(res, 400, { message: validation.message });
+      }
+
+      const timestamp = new Date().toISOString();
+      const lead = {
+        id: randomUUID(),
+        ...validation.value,
+        status: 'new',
+        createdAt: timestamp,
+        updatedAt: timestamp
+      };
+
+      const leads = readLeads();
+      leads.unshift(lead);
+      writeLeads(leads);
+
+      return sendJson(res, 201, {
+        message: '提交成功，我们会尽快与您联系。',
+        data: lead
+      });
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        return sendJson(res, 400, { message: '请求格式不正确。' });
+      }
+
+      return sendJson(res, 500, { message: '提交失败，请稍后重试。' });
+    }
+  }
+
+  if (req.method === 'GET' && url.pathname === '/api/admin/leads') {
+    return sendJson(res, 200, { data: readLeads() });
+  }
+
+  const statusMatch = url.pathname.match(/^\/api\/admin\/leads\/([^/]+)\/status$/);
+  if (req.method === 'PATCH' && statusMatch) {
+    try {
+      const rawBody = await collectBody(req);
+      const parsedBody = rawBody ? JSON.parse(rawBody) : {};
+      const result = updateLeadStatus(statusMatch[1], parsedBody.status);
+
+      if (!result.ok) {
+        return sendJson(res, result.statusCode, { message: result.message });
+      }
+
+      return sendJson(res, 200, {
+        message: '状态更新成功。',
+        data: result.value
+      });
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        return sendJson(res, 400, { message: '请求格式不正确。' });
+      }
+
+      return sendJson(res, 500, { message: '状态更新失败，请稍后重试。' });
+    }
+  }
+
+  return sendJson(res, 404, { message: 'Not Found' });
+});
+
+ensureLeadsFile();
+
+if (require.main === module) {
+  server.listen(PORT, () => {
+    console.log(`Server running at http://localhost:${PORT}`);
+  });
+}
+
+module.exports = {
+  server,
+  validateLead,
+  readLeads,
+  writeLeads,
+  updateLeadStatus,
+  leadsFile,
+  VALID_STATUSES
+};

--- a/server.test.js
+++ b/server.test.js
@@ -1,0 +1,82 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const { server, writeLeads, leadsFile } = require('./server');
+
+let app;
+let baseUrl;
+
+test.before(async () => {
+  writeLeads([]);
+  app = server.listen(0);
+  await new Promise((resolve) => app.once('listening', resolve));
+  const address = app.address();
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+test.after(async () => {
+  writeLeads([]);
+  await new Promise((resolve, reject) => {
+    app.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test('creates, lists and updates leads with admin api', async () => {
+  const createResponse = await fetch(`${baseUrl}/api/leads`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: 'Alice',
+      phone: '13800000000',
+      company: 'Tokfinity',
+      message: 'Need a demo'
+    })
+  });
+
+  assert.equal(createResponse.status, 201);
+  const created = await createResponse.json();
+  assert.equal(created.data.status, 'new');
+
+  const listResponse = await fetch(`${baseUrl}/api/admin/leads`);
+  assert.equal(listResponse.status, 200);
+  const listPayload = await listResponse.json();
+  assert.equal(listPayload.data.length, 1);
+  assert.equal(listPayload.data[0].name, 'Alice');
+
+  const updateResponse = await fetch(`${baseUrl}/api/admin/leads/${created.data.id}/status`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status: 'contacted' })
+  });
+
+  assert.equal(updateResponse.status, 200);
+  const updated = await updateResponse.json();
+  assert.equal(updated.data.status, 'contacted');
+
+  const persisted = JSON.parse(await fs.readFile(leadsFile, 'utf8'));
+  assert.equal(persisted[0].status, 'contacted');
+});
+
+test('serves admin page and rejects invalid status values', async () => {
+  writeLeads([]);
+
+  const createResponse = await fetch(`${baseUrl}/api/leads`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: 'Bob', phone: '13900000000' })
+  });
+  const created = await createResponse.json();
+
+  const pageResponse = await fetch(`${baseUrl}/admin`);
+  assert.equal(pageResponse.status, 200);
+  const pageHtml = await pageResponse.text();
+  assert.match(pageHtml, /线索列表/);
+
+  const invalidStatusResponse = await fetch(`${baseUrl}/api/admin/leads/${created.data.id}/status`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status: 'pending' })
+  });
+
+  assert.equal(invalidStatusResponse.status, 400);
+});


### PR DESCRIPTION
## 概述
实现后台管理页面路由（/admin），展示线索管理列表。

## 改动
- 添加 Node.js HTTP 服务器，包含线索 CRUD API
- GET /api/admin/leads 获取线索列表
- PATCH /api/admin/leads/:id/status 更新线索状态
- POST /api/leads 创建线索
- /admin 路由展示线索表格（name, phone, company, message, status, createdAt）
- 状态切换控件支持 new/contacted/closed
- 更新成功后自动刷新列表
- 添加服务端测试（2 个测试用例全部通过）

## 技术栈
- Node.js 原生 HTTP 模块
- 本地 JSON 文件存储
- 原生 HTML/CSS/JS 前端