### PR TITLE
feat: implement leads storage and query API

### DIFF
--- a/data/leads.json
+++ b/data/leads.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "e6040bb9-2b7a-4f7f-bde4-35350c8a42b2",
+    "name": "Bob",
+    "phone": "13900000000",
+    "company": "",
+    "message": "",
+    "status": "new",
+    "createdAt": "2026-04-16T03:37:51.243Z",
+    "updatedAt": "2026-04-16T03:37:51.243Z"
+  },
+  {
+    "id": "1b34491e-e91c-425b-8f7b-ae2b3e8e8e55",
+    "name": "Alice",
+    "phone": "13800000000",
+    "company": "Tokfinity",
+    "message": "Need a demo",
+    "status": "contacted",
+    "createdAt": "2026-04-16T03:37:51.234Z",
+    "updatedAt": "2026-04-16T03:37:51.240Z"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "hello-world",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Lead storage and management MVP API",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "test": "node --test"
+  }
+}

--- a/src/leadStore.js
+++ b/src/leadStore.js
@@ -1,0 +1,108 @@
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const DATA_DIR = path.join(__dirname, '..', 'data');
+const DATA_FILE = path.join(DATA_DIR, 'leads.json');
+const VALID_STATUSES = ['new', 'contacted', 'closed'];
+
+async function ensureStore() {
+  await fs.mkdir(DATA_DIR, { recursive: true });
+  try {
+    await fs.access(DATA_FILE);
+  } catch {
+    await fs.writeFile(DATA_FILE, '[]\n', 'utf8');
+  }
+}
+
+async function readLeads() {
+  await ensureStore();
+  const raw = await fs.readFile(DATA_FILE, 'utf8');
+  const parsed = JSON.parse(raw || '[]');
+  return Array.isArray(parsed) ? parsed : [];
+}
+
+async function writeLeads(leads) {
+  await ensureStore();
+  await fs.writeFile(DATA_FILE, `${JSON.stringify(leads, null, 2)}\n`, 'utf8');
+}
+
+function validateLeadInput(payload) {
+  if (!payload || typeof payload !== 'object') {
+    return 'Invalid request body';
+  }
+  if (!String(payload.name || '').trim()) {
+    return 'name is required';
+  }
+  if (!String(payload.phone || '').trim()) {
+    return 'phone is required';
+  }
+  return '';
+}
+
+function normalizeLeadInput(payload) {
+  return {
+    name: String(payload.name || '').trim(),
+    phone: String(payload.phone || '').trim(),
+    company: String(payload.company || '').trim(),
+    message: String(payload.message || '').trim(),
+  };
+}
+
+async function createLead(payload) {
+  const error = validateLeadInput(payload);
+  if (error) {
+    const err = new Error(error);
+    err.statusCode = 400;
+    throw err;
+  }
+
+  const input = normalizeLeadInput(payload);
+  const now = new Date().toISOString();
+  const lead = {
+    id: crypto.randomUUID(),
+    ...input,
+    status: 'new',
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  const leads = await readLeads();
+  leads.unshift(lead);
+  await writeLeads(leads);
+  return lead;
+}
+
+async function listLeads() {
+  return readLeads();
+}
+
+async function updateLeadStatus(id, status) {
+  if (!VALID_STATUSES.includes(status)) {
+    const err = new Error('status must be one of: new, contacted, closed');
+    err.statusCode = 400;
+    throw err;
+  }
+
+  const leads = await readLeads();
+  const lead = leads.find((item) => item.id === id);
+  if (!lead) {
+    const err = new Error('Lead not found');
+    err.statusCode = 404;
+    throw err;
+  }
+
+  lead.status = status;
+  lead.updatedAt = new Date().toISOString();
+  await writeLeads(leads);
+  return lead;
+}
+
+module.exports = {
+  DATA_FILE,
+  VALID_STATUSES,
+  createLead,
+  listLeads,
+  updateLeadStatus,
+  writeLeads,
+};

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,73 @@
+const http = require('node:http');
+const { URL } = require('node:url');
+const { createLead, listLeads, updateLeadStatus } = require('./leadStore');
+
+async function readJsonBody(req) {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+  const raw = Buffer.concat(chunks).toString('utf8').trim();
+  if (!raw) {
+    return {};
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    const err = new Error('Invalid JSON body');
+    err.statusCode = 400;
+    throw err;
+  }
+}
+
+function sendJson(res, statusCode, payload) {
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json; charset=utf-8',
+  });
+  res.end(JSON.stringify(payload));
+}
+
+async function requestListener(req, res) {
+  const url = new URL(req.url, 'http://127.0.0.1');
+  const { method } = req;
+
+  try {
+    if (method === 'POST' && url.pathname === '/api/leads') {
+      const lead = await createLead(await readJsonBody(req));
+      return sendJson(res, 201, { data: lead });
+    }
+
+    if (method === 'GET' && url.pathname === '/api/admin/leads') {
+      const leads = await listLeads();
+      return sendJson(res, 200, { data: leads });
+    }
+
+    const match = url.pathname.match(/^\/api\/admin\/leads\/([^/]+)\/status$/);
+    if (method === 'PATCH' && match) {
+      const lead = await updateLeadStatus(match[1], (await readJsonBody(req)).status);
+      return sendJson(res, 200, { data: lead });
+    }
+
+    return sendJson(res, 404, { error: 'Not found' });
+  } catch (error) {
+    return sendJson(res, error.statusCode || 500, {
+      error: error.message || 'Internal server error',
+    });
+  }
+}
+
+function createServer() {
+  return http.createServer(requestListener);
+}
+
+if (require.main === module) {
+  const port = Number(process.env.PORT || 3000);
+  const server = createServer();
+  server.listen(port, () => {
+    console.log(`Server listening on http://127.0.0.1:${port}`);
+  });
+}
+
+module.exports = {
+  createServer,
+};

--- a/test/leads-api.test.js
+++ b/test/leads-api.test.js
@@ -1,0 +1,86 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const { createServer } = require('../src/server');
+const { DATA_FILE, writeLeads } = require('../src/leadStore');
+
+let server;
+let baseUrl;
+
+test.before(async () => {
+  await writeLeads([]);
+  server = createServer();
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+test.after(async () => {
+  if (server) {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test('creates, lists and updates leads with file persistence', async () => {
+  const createResponse = await fetch(`${baseUrl}/api/leads`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: 'Alice',
+      phone: '13800000000',
+      company: 'Tokfinity',
+      message: 'Need a demo',
+    }),
+  });
+
+  assert.equal(createResponse.status, 201);
+  const created = await createResponse.json();
+  assert.equal(created.data.name, 'Alice');
+  assert.equal(created.data.status, 'new');
+
+  const listResponse = await fetch(`${baseUrl}/api/admin/leads`);
+  assert.equal(listResponse.status, 200);
+  const listed = await listResponse.json();
+  assert.equal(listed.data.length, 1);
+  assert.equal(listed.data[0].id, created.data.id);
+
+  const patchResponse = await fetch(`${baseUrl}/api/admin/leads/${created.data.id}/status`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status: 'contacted' }),
+  });
+
+  assert.equal(patchResponse.status, 200);
+  const updated = await patchResponse.json();
+  assert.equal(updated.data.status, 'contacted');
+
+  const rawFile = await fs.readFile(DATA_FILE, 'utf8');
+  const persisted = JSON.parse(rawFile);
+  assert.equal(persisted.length, 1);
+  assert.equal(persisted[0].status, 'contacted');
+});
+
+test('rejects invalid lead creation and invalid status update', async () => {
+  const invalidCreate = await fetch(`${baseUrl}/api/leads`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ phone: '13800000000' }),
+  });
+  assert.equal(invalidCreate.status, 400);
+
+  const createResponse = await fetch(`${baseUrl}/api/leads`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: 'Bob', phone: '13900000000' }),
+  });
+  const created = await createResponse.json();
+
+  const invalidStatus = await fetch(`${baseUrl}/api/admin/leads/${created.data.id}/status`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status: 'pending' }),
+  });
+  assert.equal(invalidStatus.status, 400);
+});


### PR DESCRIPTION
Implements lead storage and query API with three endpoints:

- POST /api/leads - Create new lead
- GET /api/admin/leads - List all leads  
- PATCH /api/admin/leads/:id/status - Update lead status

Uses local JSON file for persistence.